### PR TITLE
fix: pass arrow function to promise resolver

### DIFF
--- a/rmmz_managers.js
+++ b/rmmz_managers.js
@@ -688,8 +688,8 @@ StorageManager.saveToForage = function(saveName, zip) {
     setTimeout(() => localforage.removeItem(testKey));
     return localforage
         .setItem(testKey, zip)
-        .then(localforage.setItem(key, zip))
-        .then(this.updateForageKeys());
+        .then(() => localforage.setItem(key, zip))
+        .then(() => this.updateForageKeys());
 };
 
 StorageManager.loadFromForage = function(saveName) {
@@ -704,7 +704,7 @@ StorageManager.forageExists = function(saveName) {
 
 StorageManager.removeForage = function(saveName) {
     const key = this.forageKey(saveName);
-    return localforage.removeItem(key).then(this.updateForageKeys());
+    return localforage.removeItem(key).then(() => this.updateForageKeys());
 };
 
 StorageManager.updateForageKeys = function() {


### PR DESCRIPTION
### Issue
修正前の `StorageManager.saveToForage()` の記述

>        .then(localforage.setItem(key, zip))
>        .then(this.updateForageKeys());

では Promise を then の引数 onFulfilled に渡すことになってしまっている。
正しくは Promise **を返す関数**を渡すべきである。

結果、Promise チェーンでの非同期待ちが意図通り行われていない。
console.log() デバッグしてみると、`localforage.setItem()` の完了前に `this.updateForageKeys()` が完了してしまっていたりする。

幸い通常の使用ではこれらの順序が前後しても致命的な問題は発生していないが、
ループを回して大量にセーブをしたり、プラグインから追加の処理が挿入された場合にバグのもとになることが考えられる。

### Fix
該当箇所をアロー関数で包んだ。

#### Note
`.then(this.updateForageKeys())` に関しては呼び出しを行わずこの関数値をそのまま渡す形

> .then(this.updateForageKeys);

でも型は合うが、前段の Promise から値を受け取らないことを明示する意味でも、
他の箇所と記述を揃える意味でもアロー関数を使用したほうがよいと考える。